### PR TITLE
Fix example config key

### DIFF
--- a/.shopworker.example.json
+++ b/.shopworker.example.json
@@ -1,5 +1,5 @@
 {
-  "last_deployed_commit": "f089461dad4ba5c052d5ea9ecfc65c744ecb2387",
+  "lastDeployedCommit": "f089461dad4ba5c052d5ea9ecfc65c744ecb2387",
   "cloudflare_worker_url": "https://shopworker.your0cloudflare-subdomain.workers.dev",
   "shops": [
     {


### PR DESCRIPTION
## Summary
- use camelCase `lastDeployedCommit` key in `.shopworker.example.json`

## Testing
- `npm test` *(fails: Cannot find package 'commander')*
- `npm install` *(fails: network EHOSTUNREACH)*