### PR TITLE
Add Zendesk ticket creation for low reviews

### DIFF
--- a/connectors/zendesk.js
+++ b/connectors/zendesk.js
@@ -1,0 +1,24 @@
+export async function createZendeskTicket(auth, ticket) {
+  const { subdomain, email, apiToken } = auth;
+  if (!subdomain || !email || !apiToken) {
+    throw new Error('Missing Zendesk credentials');
+  }
+
+  const credentials = Buffer.from(`${email}/token:${apiToken}`).toString('base64');
+
+  const response = await fetch(`https://${subdomain}.zendesk.com/api/v2/tickets.json`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Basic ${credentials}`
+    },
+    body: JSON.stringify({ ticket })
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Zendesk API error: ${response.status} ${response.statusText} - ${text}`);
+  }
+
+  return response.json();
+}

--- a/jobs/review/low-rating-to-zendesk/config.json
+++ b/jobs/review/low-rating-to-zendesk/config.json
@@ -1,0 +1,7 @@
+{
+  "name": "Create Zendesk ticket for low review",
+  "shop": "example-shop",
+  "description": "When a review of 2 stars or less is created, open a Zendesk ticket",
+  "version": "1.0.0",
+  "trigger": "review-created"
+}

--- a/jobs/review/low-rating-to-zendesk/job.js
+++ b/jobs/review/low-rating-to-zendesk/job.js
@@ -1,0 +1,26 @@
+import { createZendeskTicket } from '../../../connectors/zendesk.js';
+
+/**
+ * Create a Zendesk ticket when a low-rated review is received
+ * @param {Object} options - Job options
+ * @param {Object} options.record - Review data
+ * @param {Object} options.env - Environment variables
+ * @param {Object} options.secrets - Secrets with Zendesk credentials
+ */
+export async function process({ record: review, env, secrets }) {
+  const rating = review.rating ?? review.stars ?? review.starRating;
+  if (rating === undefined || rating > 2) {
+    return;
+  }
+
+  const auth = {
+    subdomain: env.ZENDESK_SUBDOMAIN || secrets.ZENDESK_SUBDOMAIN,
+    email: env.ZENDESK_EMAIL || secrets.ZENDESK_EMAIL,
+    apiToken: env.ZENDESK_API_TOKEN || secrets.ZENDESK_API_TOKEN
+  };
+
+  const subject = `Low review (${rating}\u2605)`;
+  const body = review.body || review.message || '';
+
+  await createZendeskTicket(auth, { subject, comment: { body } });
+}

--- a/triggers/review-created.json
+++ b/triggers/review-created.json
@@ -1,0 +1,9 @@
+{
+  "name": "Review Created",
+  "webhook": {
+    "topic": "reviews/create"
+  },
+  "test": {
+    "skipQuery": true
+  }
+}


### PR DESCRIPTION
## Summary
- add Zendesk connector helper
- support `review-created` trigger
- add job to open Zendesk ticket when rating is 2 stars or less

## Testing
- `npm run lint` *(fails: Cannot use import statement outside a module)*