### PR TITLE
Add ESLint rule for job try/catch usage

### DIFF
--- a/eslint-plugin-custom/index.js
+++ b/eslint-plugin-custom/index.js
@@ -1,0 +1,25 @@
+export default {
+  rules: {
+    'no-try-catch-in-job': {
+      meta: {
+        type: 'problem',
+        docs: {
+          description: 'Disallow try/catch blocks in job files'
+        },
+        messages: {
+          noTryCatch: 'Try/catch blocks are not allowed in job files. Handle errors in the caller.'
+        }
+      },
+      create(context) {
+        return {
+          TryStatement(node) {
+            const filename = context.getFilename();
+            if (/\bjobs\/.*job\.js$/.test(filename)) {
+              context.report({ node, messageId: 'noTryCatch' });
+            }
+          }
+        };
+      }
+    }
+  }
+};

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,11 @@
+import customPlugin from './eslint-plugin-custom/index.js';
+
+export default [
+  {
+    ignores: ['node_modules/**'],
+    plugins: { custom: customPlugin },
+    rules: {
+      'custom/no-try-catch-in-job': 'warn'
+    }
+  }
+];

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "all-webhooks": "node cli.js all-webhooks",
     "delete-webhook": "node cli.js delete-webhook",
     "put-secrets": "node cli.js put-secrets",
-    "generate-structure": "node tools/generate-codebase-structure.js"
+    "generate-structure": "node tools/generate-codebase-structure.js",
+    "lint": "eslint ."
   },
   "dependencies": {
     "acorn": "^8.11.3",
@@ -27,5 +28,8 @@
     "date-fns": "^3.2.0",
     "googleapis": "^131.0.0",
     "jose": "^5.10.0"
+  },
+  "devDependencies": {
+    "eslint": "^9.27.0"
   }
 }


### PR DESCRIPTION
## Summary
- configure ESLint using the Flat config
- implement custom `no-try-catch-in-job` rule
- add lint script and dev dependency
- keep product to-google-sheets job without a try/catch wrapper

## Testing
- `npx eslint` *(reports warnings for job files with try/catch)*
- `npm test` *(fails: Could not detect job directory)*