### PR TITLE
Change job process arg to payload

### DIFF
--- a/job-queue.js
+++ b/job-queue.js
@@ -172,7 +172,7 @@ export class JobQueue extends DurableObject {
 
       // Process the job with complete data
       await jobModule.process({
-        record: bodyData,
+        payload: bodyData,
         shopify,
         env: this.env,
         shopConfig,

--- a/jobs/avery/import-orders-from-webhook-csv/job.js
+++ b/jobs/avery/import-orders-from-webhook-csv/job.js
@@ -16,14 +16,14 @@ let jobConfig;
 let env;
 let shopConfig;
 
-export async function process({ record, shopify: shopifyClient, jobConfig: config, env: environment, shopConfig: shop }) {
+export async function process({ payload, shopify: shopifyClient, jobConfig: config, env: environment, shopConfig: shop }) {
   // Set module-level variables
   shopify = shopifyClient;
   jobConfig = config;
   env = environment;
   shopConfig = shop;
 
-  const decodedContent = validateAndDecodeAttachment(record);
+  const decodedContent = validateAndDecodeAttachment(payload);
   const parsedData = parseCSVContent(decodedContent);
 
   if (parsedData.rows.length === 0) {

--- a/jobs/avery/process-single-order/job.js
+++ b/jobs/avery/process-single-order/job.js
@@ -22,13 +22,13 @@ import AddCustomerTags from "../../../graphql/AddCustomerTags.js";
 let shopify;
 let jobConfig;
 
-export async function process({ record, shopify: shopifyClient, jobConfig: config }) {
+export async function process({ payload, shopify: shopifyClient, jobConfig: config }) {
   // Set module-level variables
   shopify = shopifyClient;
   jobConfig = config;
 
   // Extract order data from the record (passed from parent job)
-  const { csOrder, orderCounter } = record;
+  const { csOrder, orderCounter } = payload;
 
   const shopifyOrderData = buildShopifyOrderData(csOrder, orderCounter);
 

--- a/jobs/city/order-to-google-sheets/job.js
+++ b/jobs/city/order-to-google-sheets/job.js
@@ -7,14 +7,14 @@ import * as CitySheets from "../city-sheets-common.js";
 /**
  * Process a Shopify order and add it to Google Sheets
  * @param {Object} options - Options object
- * @param {Object} options.record - Shopify order data
+ * @param {Object} options.payload - Shopify order data
  * @param {Object} options.shopify - Shopify API client
  * @param {Object} options.env - Environment variables
  * @param {Object} options.shopConfig - Shop-specific configuration
  * @param {Object} options.jobConfig - Job-specific configuration from config.json
  * @param {Object} options.secrets - Secrets loaded from files or environment
  */
-export async function process({ record: orderData, shopify, env, jobConfig, secrets }) {
+export async function process({ payload: orderData, shopify, env, jobConfig, secrets }) {
   logToWorker(env, "Webhook payload: " + JSON.stringify(orderData));
 
   if (!orderData.id) {

--- a/jobs/cutting/mollie-invoice-link/job.js
+++ b/jobs/cutting/mollie-invoice-link/job.js
@@ -94,7 +94,7 @@ async function sendShopifyInvoiceWithLink(orderId, paymentLink, shopify) {
  * @param {Object} params.shopify - Shopify API client
  * @param {Object} params.env - Environment variables specific to the job's execution context
  */
-export async function process({ record: order, shopify, env }) {
+export async function process({ payload: order, shopify, env }) {
   validateEnvironment(env);
 
   const orderDetails = await getAugmentedOrderDetails(order, shopify);

--- a/jobs/fruit/monthly-b2b-orders-csv/job.js
+++ b/jobs/fruit/monthly-b2b-orders-csv/job.js
@@ -7,7 +7,7 @@ import { format, parseISO } from "date-fns";
 /**
  * Process orders and send email with CSV attachment
  * @param {Object} params - Parameters for the job
- * @param {Object} params.record - The record object (empty for manual jobs)
+ * @param {Object} params.payload - The payload object (empty for manual jobs)
  * @param {Object} params.shopify - Shopify API client
  * @param {Object} params.env - Environment variables
  * @param {Object} params.secrets - Secrets loaded from files or environment

--- a/jobs/order/fetch/job.js
+++ b/jobs/order/fetch/job.js
@@ -6,9 +6,9 @@ import GetOrderById from "../../../graphql/GetOrderById.js";
  * @param {Object} params.shopify - Shopify API client
  * @param {Object} [params.env] - Environment variables (not used by this job)
  */
-export async function process({ record, shopify }) {
+export async function process({ payload, shopify }) {
   // Convert ID to GID format and fetch full order
-  const orderId = shopify.toGid(record.id, "Order");
+  const orderId = shopify.toGid(payload.id, "Order");
   const { order } = await shopify.graphql(GetOrderById, { id: orderId });
 
   console.log(order);

--- a/jobs/order/tag-skus-when-created/job.js
+++ b/jobs/order/tag-skus-when-created/job.js
@@ -7,7 +7,7 @@ import OrderUpdate from "../../../graphql/OrderUpdate.js";
  * @param {Object} params.shopify - Shopify API client
  * @param {Object} [params.env] - Environment variables (not used by this job)
  */
-export async function process({ record: order, shopify }) {
+export async function process({ payload: order, shopify }) {
   // Extract SKUs from line items
   const skus = [];
 

--- a/jobs/product/set-metafield-when-created/job.js
+++ b/jobs/product/set-metafield-when-created/job.js
@@ -6,7 +6,7 @@ import ProductMetafieldUpdate from "../../../graphql/ProductMetafieldUpdate.js";
  * @param {Object} params.shopify - Shopify API client
  * @param {Object} [params.env] - Environment variables (not used by this job)
  */
-export async function process({ record: product, shopify }) {
+export async function process({ payload: product, shopify }) {
   // Format the current date in ISO format
   const currentDate = new Date().toISOString();
 

--- a/jobs/product/tag-when-title-updated/job.js
+++ b/jobs/product/tag-when-title-updated/job.js
@@ -23,10 +23,10 @@ function getFormattedDate() {
 /**
  * Process a product update and add a last-modified tag
  * @param {Object} options - Options object
- * @param {Object} options.record - Shopify product data
+ * @param {Object} options.payload - Shopify product data
  * @param {Object} options.shopify - Shopify API client
  */
-export async function process({ record: productData, shopify }) {
+export async function process({ payload: productData, shopify }) {
   console.log("====== Processing product update to add last-modified tag ======", productData);
 
   const productId = shopify.toGid(productData.id, "Product");

--- a/jobs/product/to-google-sheets/job.js
+++ b/jobs/product/to-google-sheets/job.js
@@ -251,13 +251,13 @@ async function appendProductRows(sheetsClient, spreadsheetId, sheetName, rows, c
 /**
  * Process a product update and save/update it in Google Sheets
  * @param {Object} options - Options object
- * @param {Object} options.record - Shopify product data from webhook
+ * @param {Object} options.payload - Shopify product data from webhook
  * @param {Object} options.shopify - Shopify API client
  * @param {Object} options.env - Environment variables
  * @param {Object} options.shopConfig - Shop-specific configuration
  * @param {Object} options.jobConfig - Job-specific configuration from config.json
  */
-export async function process({ record: productData, shopify, env, jobConfig, secrets }) {
+export async function process({ payload: productData, shopify, env, jobConfig, secrets }) {
   console.log("Product webhook payload received");
   logToWorker(env, "Webhook payload: " + JSON.stringify(productData));
 

--- a/jobs/review/low-rating-to-zendesk/job.js
+++ b/jobs/review/low-rating-to-zendesk/job.js
@@ -3,11 +3,11 @@ import { createZendeskTicket } from '../../../connectors/zendesk.js';
 /**
  * Create a Zendesk ticket when a low-rated review is received
  * @param {Object} options - Job options
- * @param {Object} options.record - Review data
+ * @param {Object} options.payload - Review data
  * @param {Object} options.env - Environment variables
  * @param {Object} options.secrets - Secrets with Zendesk credentials
  */
-export async function process({ record: review, env, secrets }) {
+export async function process({ payload: review, env, secrets }) {
   const rating = review.rating ?? review.stars ?? review.starRating;
   if (rating === undefined || rating > 2) {
     return;

--- a/utils/env.js
+++ b/utils/env.js
@@ -29,7 +29,7 @@ export function isCliEnvironment(env) {
 export async function runSubJob({ jobPath, record, shopify, jobConfig, env, shopConfig }) {
   if (isCliEnvironment(env)) {
     console.log(chalk.green(`  ✓ Processing subjob#${record.subJobIndex} directly in CLI`));
-    await runSubJobDirectly({ jobPath, record, shopify, jobConfig });
+    await runSubJobDirectly({ jobPath, payload: record, shopify, jobConfig });
   } else {
     // Cloudflare Workers Environment: Queue the job via durable object
     if (!shopConfig || !shopConfig.shopify_domain) {
@@ -45,11 +45,11 @@ export async function runSubJob({ jobPath, record, shopify, jobConfig, env, shop
  * Run a sub-job directly by importing and calling it (CLI environment)
  * @param {Object} options - Options for running the sub-job
  * @param {string} options.jobPath - Path to the job
- * @param {Object} options.record - Record data to pass to the sub-job
+ * @param {Object} options.payload - Payload data to pass to the sub-job
  * @param {Object} options.shopify - Shopify API client
  * @param {Object} options.jobConfig - Job configuration
  */
-async function runSubJobDirectly({ jobPath, record, shopify, jobConfig }) {
+async function runSubJobDirectly({ jobPath, payload, shopify, jobConfig }) {
   // Dynamically import the job module
   const jobModule = await import(`../jobs/${jobPath}/job.js`);
 
@@ -59,7 +59,7 @@ async function runSubJobDirectly({ jobPath, record, shopify, jobConfig }) {
 
   // Call the job's process function directly
   await jobModule.process({
-    record,
+    payload,
     shopify,
     jobConfig
   });

--- a/utils/job-management.js
+++ b/utils/job-management.js
@@ -285,7 +285,7 @@ export async function runJobTest(cliDirname, jobPath, queryParam, shopParam) {
 
   // Pass process.env as env, shopConfig as shopConfig, and secrets for consistency with worker environment
   await jobModule.process({
-    record,
+    payload: record,
     shopify: shopify,
     env: process.env,   // Pass Node.js process.env as env
     shopConfig: shopConfig,  // Pass shopConfig separately

--- a/worker.js
+++ b/worker.js
@@ -161,7 +161,7 @@ async function processWebhook(jobModule, bodyData, shopify, env, shopConfig, job
   const secrets = loadSecretsFromEnv(env);
 
   await jobModule.process({
-    record: bodyData,
+    payload: bodyData,
     shopify,
     env,
     shopConfig,


### PR DESCRIPTION
## Summary
- rename `record` parameter to `payload` in all job `process` methods
- update all calls to `jobModule.process()` accordingly
- adjust helper to pass payload to sub-jobs
- tweak related comments

## Testing
- `npm run lint` *(fails: Cannot find module 'eslint-plugin-custom')*
- `npm test` *(fails: Could not detect job directory)*

------
https://chatgpt.com/codex/tasks/task_e_68432925f078832886f90407beeef313